### PR TITLE
Custom headers

### DIFF
--- a/lib/paubox.rb
+++ b/lib/paubox.rb
@@ -18,6 +18,10 @@ module Paubox
     yield(configuration)
   end
 
+  def self.reset_configuration!
+    self.configuration = Configuration.new
+  end
+
   class Configuration
     attr_accessor :api_key, :api_user
   end

--- a/lib/paubox/client.rb
+++ b/lib/paubox/client.rb
@@ -67,8 +67,8 @@ module Paubox
     end
 
     def defaults
-      { api_key: Paubox.configuration.api_key,
-        api_user: Paubox.configuration.api_user,
+      { api_key: Paubox.configuration.api_key || '',
+        api_user: Paubox.configuration.api_user || '',
         api_host: 'api.paubox.net',
         api_protocol: 'https://',
         api_version: 'v1',

--- a/lib/paubox/version.rb
+++ b/lib/paubox/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Paubox
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/spec/helpers/mail_helper.rb
+++ b/spec/helpers/mail_helper.rb
@@ -54,10 +54,17 @@ module Helpers
     def message_with_attachments(args = {})
       mail = multipart_message(args)
       file = Tempfile.new(['test', '.csv'])
-      file.write('first, second')
-      file.close
-      mail.add_file(file.path)
-      mail
+      begin
+        file.write('first, second')
+      ensure
+        file.close
+      end
+      begin
+        mail.add_file(file.path)
+        mail
+      ensure
+        file.unlink
+      end
     end
 
     def base64_encode_if_needed(str)

--- a/spec/helpers/message_helper.rb
+++ b/spec/helpers/message_helper.rb
@@ -40,11 +40,11 @@ module Helpers
                                                      content: 'first, second '] }.merge(args))
     end
 
-    def message_with_force_secure_notification_args(args = {})
+    def message_with_force_secure_notification_string_args(args = {})
       base_message_args({ force_secure_notification: 'true' }.merge(args))
     end
 
-    def message_with_invalid_force_secure_notification_args(args = {})
+    def message_with_force_secure_notification_boolean_args(args = {})
       base_message_args({ force_secure_notification: true }.merge(args))
     end
 

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -9,14 +9,12 @@ end
 
 RSpec.describe Mail::Message do
   describe 'extends class' do
-    before do
+
+    it 'sets source_tracking_id' do
       Paubox.configure do |config|
         config.api_key = 'test_key'
         config.api_user = 'test_user'
       end
-    end
-
-    it 'sets source_tracking_id' do
       mail = message_with_attachments
       client = Paubox::Client.new
       stub_request(:post, client.send(:request_endpoint, 'messages'))

--- a/spec/mail/paubox_spec.rb
+++ b/spec/mail/paubox_spec.rb
@@ -9,14 +9,11 @@ end
 
 RSpec.describe Mail::Paubox do
   describe '#deliver!' do
-    before do
+    it 'delivers a Mail message via the Transactional Email API' do
       Paubox.configure do |config|
         config.api_key = 'test_key'
         config.api_user = 'test_user'
       end
-    end
-
-    it 'delivers a Mail message via the Transactional Email API' do
       mail = message_with_attachments
       client = Paubox::Client.new
       stub_request(:post, client.send(:request_endpoint, 'messages'))

--- a/spec/paubox/client_spec.rb
+++ b/spec/paubox/client_spec.rb
@@ -9,13 +9,6 @@ end
 
 RSpec.describe Paubox::Client do
   describe '#initialize' do
-    before do
-      Paubox.configure do |config|
-        config.api_key = 'test_key'
-        config.api_user = 'test_user'
-      end
-    end
-
     it 'can override default parameters' do
       client = Paubox::Client.new(api_key: 'test_key', api_user: 'paubox_test',
                                   api_protocol: '', api_host: 'localhost:3000', api_version: 'v2')

--- a/spec/paubox/message_spec.rb
+++ b/spec/paubox/message_spec.rb
@@ -17,6 +17,23 @@ RSpec.describe Paubox::Message do
       expect(message.send(:build_headers)).to eq expected_results
     end
 
+    it 'builds custom headers' do
+      message_args = message_with_attachment_args.merge({
+        custom_headers: {
+          'header-1': 'Header-1-value',
+          'Header-2': 'Header-2-value',
+          'X-header-3': 'Header-3-value',
+          'x-Header-4': 'Header-4-value'
+        }
+      })
+      message = Paubox::Message.new(message_args)
+      custom_headers = message.send(:build_custom_headers)
+      normalized_header_keys = [1,2,3,4].map { |i| "x-header-#{i}" }
+      normalized_header_keys.each do |k|
+        expect(custom_headers[k]).to be_a(String)
+      end
+    end
+
     it 'builds content' do
       message = Paubox::Message.new(message_with_attachment_args)
       tested_keys = %i[text_content html_content]
@@ -32,32 +49,40 @@ RSpec.describe Paubox::Message do
     it 'adds additional attachments with #add_attachment' do
       message = Paubox::Message.new(message_with_attachment_args)
       file = Tempfile.new(['test', '.csv'])
-      file.write('first, second')
-      file.close
-      message.add_attachment(file.path)
-      expect(message.attachments.length).to be 2
+      begin
+        file.write('first, second')
+        message.add_attachment(file.path)
+        expect(message.attachments.length).to be 2
+      ensure
+        file.close
+        file.unlink
+      end
     end
 
     it 'base64 encodes all attachment file contents' do
       message = Paubox::Message.new(message_with_attachment_args)
       file = Tempfile.new(['test', '.csv'])
-      file.write('first, second')
-      file.close
-      message.add_attachment(file.path)
-      expect(message.attachments.map { |a| base64_encoded?(a[:content]) }.uniq).to eq [true]
+      begin
+        file.write('first, second')
+        message.add_attachment(file.path)
+        expect(message.attachments.map { |a| base64_encoded?(a[:content]) }.uniq).to eq [true]
+      ensure
+        file.close
+        file.unlink
+      end
     end
 
-    it 'builds force secure notification valid value' do
-      message = Paubox::Message.new(message_with_force_secure_notification_args)
+    it 'builds force secure notification string value' do
+      message = Paubox::Message.new(message_with_force_secure_notification_string_args)
       tested_keys = %i[force_secure_notification]
       expected_results = true
       expect(message.send(:build_force_secure_notification)).to eq expected_results
     end
 
-    it 'builds force secure notification invalid value' do
-      message = Paubox::Message.new(message_with_invalid_force_secure_notification_args)
+    it 'builds force secure notification boolean value' do
+      message = Paubox::Message.new(message_with_force_secure_notification_boolean_args)
       tested_keys = %i[force_secure_notification]
-      expected_results = nil
+      expected_results = true
       expect(message.send(:build_force_secure_notification)).to eq expected_results
     end
 

--- a/spec/paubox_spec.rb
+++ b/spec/paubox_spec.rb
@@ -7,20 +7,35 @@ RSpec.describe Paubox do
     expect(Paubox::VERSION).not_to be nil
   end
 
+  describe 'unconfigured client has empty API key and user' do
+    it 'Does not set API user' do
+      Paubox.reset_configuration!
+      client = Paubox::Client.new
+      expect(client.api_user).to eq('')
+    end
+
+    it 'Does not set API key' do
+      Paubox.reset_configuration!
+      client = Paubox::Client.new
+      expect(client.api_key).to eq('')
+    end
+  end
+
   describe '#configure' do
-    before do
+    it 'Sets the API key' do
       Paubox.configure do |config|
         config.api_key = 'test_key'
         config.api_user = 'test_user'
       end
-    end
-
-    it 'Sets the API key' do
       client = Paubox::Client.new
       expect(client.api_key).to eq 'test_key'
     end
 
     it 'Sets the API user' do
+      Paubox.configure do |config|
+        config.api_key = 'test_key'
+        config.api_user = 'test_user'
+      end
       client = Paubox::Client.new
       expect(client.api_user).to eq 'test_user'
     end


### PR DESCRIPTION
Required changes for passing custom headers to the API. Custom headers are any extra headers that clients can pass to the API which will be passed back to them with webhooks. This will allow clients to pass along any metadata that they want to be in the webhook payload.

All custom headers are normalized to be of the form "x-..." to prevent collisions with headers mandated by SMTP RFCs.