### PR TITLE
Add Paubox Forms API support with FormsClient and Form model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# Paubox Ruby Gem — Developer Context
+
+## Purpose
+
+This is the official Ruby gem for the Paubox platform. It provides:
+- **Email API**: send HIPAA-compliant email, manage dynamic templates, check delivery status
+- **Forms API**: fetch form definitions and submit form responses
+
+## Directory Structure
+
+```
+lib/
+  paubox.rb                  # Entry point: requires all lib files, holds Configuration
+  paubox_ruby.rb             # Alias for paubox.rb
+  paubox/
+    version.rb               # Gem version constant
+    client.rb                # Email API client (authenticated, api.paubox.net)
+    forms_client.rb          # Forms API client (unauthenticated, next.paubox.com)
+    message.rb               # Builds send-message API payload from a hash
+    templated_message.rb     # Extends Message for template-based sends
+    mail_to_message.rb       # Adapts Ruby Mail::Message to API payload
+    dynamic_templates.rb     # CRUD for dynamic email templates
+    email_disposition.rb     # Parses delivery/open status responses
+    form.rb                  # Parses form metadata responses
+    format_helper.rb         # Shared utilities: base64, key mapping, normalization
+  mail/
+    paubox.rb                # Plugs Paubox into Ruby Mail as a delivery method
+
+spec/
+  spec_helper.rb             # RSpec + WebMock setup
+  paubox/                    # Unit specs per class
+  mail/                      # Specs for Ruby Mail integration
+  helpers/                   # Shared fixtures (MessageHelper, FormHelper, etc.)
+```
+
+## Key Classes
+
+| Class | Responsibility |
+|---|---|
+| `Paubox::Client` | Authenticated HTTP client for the Email API. Token auth via `Authorization: Token token=<key>`. Base URL: `https://api.paubox.net/v1/<api_user>`. |
+| `Paubox::FormsClient` | Unauthenticated HTTP client for the Forms API. Base URL: `https://next.paubox.com`. No API key needed. |
+| `Paubox::Message` | Builds the JSON payload for `/messages`. Accepts `from`, `to`, `cc`, `bcc`, `subject`, `text_content`, `html_content`, `attachments`. |
+| `Paubox::TemplatedMessage` | Extends `Message`; overrides `send_message_payload` to include `template_name` / `template_values`. |
+| `Paubox::MailToMessage` | Converts a `Mail::Message` object into a Paubox API payload. |
+| `Paubox::DynamicTemplates` | Manages template CRUD via class methods (`create`, `list`, `find`) and instance methods (`update`, `delete`). |
+| `Paubox::EmailDisposition` | Parses the `/message_receipt` response into `MessageDelivery` and `MessageDeliveryStatus` structs. |
+| `Paubox::Form` | Parses the `/public/form_data/<id>` response. Exposes predicate methods: `active?`, `deleted?`, `archived?`, `signable?`. |
+| `Paubox::FormatHelper` | Mixed into message builders; handles base64 encoding, snake_case→camelCase key mapping, email list normalization. |
+| `Mail::Paubox` | Delivery method for the Ruby Mail library. Delegates to `Paubox::Client`. |
+
+## Adding a New Feature
+
+### New API endpoint on the Email API
+1. Add a method to `Paubox::Client` that calls `send_request` or `RestClient` directly.
+2. If the response needs a structured model, create `lib/paubox/<model>.rb` following `EmailDisposition` as a pattern.
+3. Require the new file in `lib/paubox.rb`.
+4. Add specs in `spec/paubox/<feature>_spec.rb` using WebMock to stub HTTP.
+
+### New API endpoint on the Forms API
+1. Add a method to `Paubox::FormsClient`.
+2. If needed, add a response model following `Paubox::Form`.
+3. Require in `lib/paubox.rb`.
+4. Add specs in `spec/paubox/forms_client_spec.rb` or a new file.
+
+## Testing
+
+**Framework:** RSpec 3 + WebMock
+
+```bash
+bundle exec rspec                    # run all specs
+bundle exec rspec spec/paubox/form_spec.rb   # run a single file
+```
+
+WebMock stubs outbound HTTP. All specs must stub any HTTP calls they trigger — no real network requests are made.
+
+Fixtures live in `spec/helpers/` as includable modules (e.g. `Helpers::FormHelper`, `Helpers::MessageHelper`). Include them per spec file with `RSpec.configure { |c| c.include Helpers::XHelper }`.
+
+## Authentication
+
+- **Email API**: `Authorization: Token token=<api_key>` header on every request. Configured via `Paubox.configure` or `Paubox::Client.new(api_key:, api_user:)`.
+- **Forms API**: No authentication. `Paubox::FormsClient` sends no auth headers.
+
+## Dependencies
+
+- `rest-client` (~> 2.0) — HTTP client
+- `mail` (>= 2.5) — Ruby Mail integration

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 <img src="https://avatars.githubusercontent.com/u/22528478?s=200&v=4" alt="Paubox" width="150px">
 
 # Paubox Gem
-This is the official Ruby wrapper for the Paubox Email API. The Paubox Email API allows your application to send secure, HIPAA compliant email via Paubox and track deliveries and opens.
+This is the official Ruby wrapper for the Paubox API. It supports the Paubox Email API — which allows your application to send secure, HIPAA compliant email via Paubox and track deliveries and opens — and the Paubox Forms API, which allows you to fetch form definitions and submit form responses.
 
 It extends the [Ruby Mail Library](https://github.com/mikel/mail) for seamless integration in your existing Ruby application. The API wrapper also allows you to construct and send messages directly without the Ruby Mail Library.
 
 # Table of Contents
 * [Installation](#installation)
-*  [Usage](#usage)
-*  [Contributing](#contributing)
-*  [License](#license)
+* [Usage](#usage)
+  * [Sending Email](#sending-messages-with-the-ruby-mail-library)
+  * [Paubox Forms](#paubox-forms)
+* [Contributing](#contributing)
+* [License](#license)
 
 
 <a name="#installation"></a>
@@ -290,6 +292,66 @@ status.opened_status
 # opened_time is only available for single-recipient messages
 status.opened_time
 => Mon, 30 Apr 2018 12:55:19 -0700
+```
+
+<a name="#paubox-forms"></a>
+## Paubox Forms
+
+The Paubox Forms API requires **no authentication** — these endpoints are public and intended for form embed use cases.
+
+### Getting Form Metadata
+
+```ruby
+require 'Paubox'
+
+client = Paubox::FormsClient.new
+form   = client.get_form('550e8400-e29b-41d4-a716-446655440000')
+
+form.title            # => "Patient Intake Form"
+form.description      # => "Please complete before your appointment."
+form.active?          # => true
+form.signable?        # => false
+form.submission_count # => 42
+form.form_html        # => "<form>...</form>"
+form.form_json        # => { ... }
+```
+
+### Submitting a Form
+
+```ruby
+require 'Paubox'
+
+client = Paubox::FormsClient.new
+
+client.submit_form('550e8400-e29b-41d4-a716-446655440000',
+  form_data: {
+    first_name: 'Jane',
+    last_name:  'Smith',
+    email:      'jane@example.com'
+  })
+```
+
+### Submitting a Form with Attachments
+
+File attachments must be base64-encoded. The maximum request size is 250 MB.
+
+```ruby
+require 'Paubox'
+require 'base64'
+
+client = Paubox::FormsClient.new
+
+client.submit_form('550e8400-e29b-41d4-a716-446655440000',
+  form_data: {
+    first_name: 'Jane',
+    signature:  '{signature_field}'
+  },
+  attachments: [
+    {
+      name:    'consent.pdf',
+      content: Base64.strict_encode64(File.binread('consent.pdf'))
+    }
+  ])
 ```
 
 <a name="#contributing"></a>

--- a/api.md
+++ b/api.md
@@ -1,0 +1,282 @@
+# Paubox Ruby Gem — API Reference
+
+## Email API
+
+### Authentication
+
+All Email API requests use token-based authentication. Configure credentials once globally or pass them per client instance.
+
+**Global configuration:**
+```ruby
+Paubox.configure do |config|
+  config.api_key  = ENV['PAUBOX_API_KEY']
+  config.api_user = ENV['PAUBOX_API_USER']
+end
+```
+
+**Per-instance:**
+```ruby
+client = Paubox::Client.new(api_key: ENV['PAUBOX_API_KEY'], api_user: ENV['PAUBOX_API_USER'])
+```
+
+**Authorization header sent on every request:**
+```
+Authorization: Token token=<api_key>
+```
+
+### Base URL
+
+```
+https://api.paubox.net/v1/<api_user>
+```
+
+All Email API paths below are relative to this base.
+
+---
+
+### Send Message
+
+**POST** `/messages`
+
+Sends a HIPAA-compliant email.
+
+**Request body:**
+```json
+{
+  "data": {
+    "message": {
+      "recipients": ["recipient@example.com"],
+      "cc": [],
+      "bcc": [],
+      "allowNonTLS": false,
+      "headers": {
+        "from": "sender@yourdomain.com",
+        "reply-to": "reply@yourdomain.com",
+        "subject": "Hello"
+      },
+      "content": {
+        "text/plain": "Plain text body",
+        "text/html": "<h1>HTML body</h1>"
+      },
+      "attachments": [
+        {
+          "fileName": "file.pdf",
+          "contentType": "application/pdf",
+          "content": "<base64-encoded content>"
+        }
+      ]
+    }
+  }
+}
+```
+
+**Optional fields:**
+- `forceSecureNotification` (`"true"` / `"false"`) — forces portal delivery
+- `allowNonTLS` (`true` / `false`) — allows delivery without TLS
+
+**Response (200):**
+```json
+{ "message": "Service OK", "sourceTrackingId": "2a3c048485aa4cf6" }
+```
+
+---
+
+### Send Templated Message
+
+**POST** `/templated_messages`
+
+Sends a message using a dynamic template.
+
+**Request body:**
+```json
+{
+  "data": {
+    "recipients": ["recipient@example.com"],
+    "headers": { "from": "sender@yourdomain.com", "subject": "Hello" },
+    "template_name": "My Template",
+    "template_values": { "first_name": "Jane", "last_name": "Smith" }
+  }
+}
+```
+
+**Response (200):**
+```json
+{ "sourceTrackingId": "166904b5-dce7-4de1-92e8-3d505c165ff5", "data": "Service OK" }
+```
+
+---
+
+### Get Email Disposition
+
+**GET** `/message_receipt?sourceTrackingId=<id>`
+
+Returns delivery and open status for a sent message.
+
+**Response (200):**
+```json
+{
+  "sourceTrackingId": "2a3c048485aa4cf6",
+  "data": {
+    "message": {
+      "id": "...",
+      "message_deliveries": [
+        {
+          "recipient": "recipient@example.com",
+          "status": {
+            "deliveryStatus": "delivered",
+            "deliveryTime": "2024-01-15T12:54:19-07:00",
+            "openedStatus": "opened",
+            "openedTime": "2024-01-15T12:55:19-07:00"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+---
+
+### Dynamic Templates
+
+All paths are relative to the Email API base URL.
+
+| Operation      | Method  | Path                          |
+|----------------|---------|-------------------------------|
+| List templates | GET     | `/dynamic_templates`          |
+| Get template   | GET     | `/dynamic_templates/<id>`     |
+| Create         | POST    | `/dynamic_templates`          |
+| Update         | PATCH   | `/dynamic_templates/<id>`     |
+| Delete         | DELETE  | `/dynamic_templates/<id>`     |
+
+**Create / Update request body** (`multipart/form-data`):
+- `data[name]` — template name
+- `data[body]` — template file
+
+---
+
+### API Status
+
+**GET** `/status`
+
+Returns service health. No authentication required in practice.
+
+**Response (200):**
+```json
+{ "message": "Service OK" }
+```
+
+---
+
+## Forms API
+
+### Authentication
+
+**None required.** Forms API endpoints are public and designed for form embed use cases. No API key or authorization header is sent.
+
+### Base URL
+
+```
+https://next.paubox.com
+```
+
+---
+
+### Get Form Metadata
+
+**GET** `/public/form_data/<form_id>`
+
+Returns the full form definition for a given UUID. Used to render a form to a respondent.
+
+**Path parameter:**
+- `form_id` (UUID, required) — the form to retrieve
+
+**Response (200):**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "title": "Patient Intake Form",
+  "description": "Please complete before your appointment.",
+  "form_json": {},
+  "form_html": "<form>...</form>",
+  "form_css": "form { font-family: sans-serif; }",
+  "vanity_url": null,
+  "version": 1,
+  "active": true,
+  "customer_id": 123,
+  "signable": false,
+  "signature_confirmation_label": null,
+  "submission_count": 42,
+  "type": null,
+  "deleted": false,
+  "archived": false,
+  "created_at": "2024-01-15T10:30:00Z",
+  "updated_at": "2024-06-01T08:00:00Z"
+}
+```
+
+**Errors:**
+- `404` — form not found
+
+**Ruby usage:**
+```ruby
+client = Paubox::FormsClient.new
+form   = client.get_form('550e8400-e29b-41d4-a716-446655440000')
+
+form.title            # => "Patient Intake Form"
+form.active?          # => true
+form.signable?        # => false
+form.submission_count # => 42
+```
+
+---
+
+### Submit Form Response
+
+**POST** `/api/forms/<form_id>/submissions`
+
+Submits a respondent's answers for a form. On success, the service stores the submission, increments the submission count, emails configured recipients, and returns 201 with no body. Maximum request size is **250 MB**.
+
+**Path parameter:**
+- `form_id` (UUID, required) — the form being submitted
+
+**Request body:**
+```json
+{
+  "form_data": {
+    "first_name": "Jane",
+    "last_name": "Smith",
+    "email": "jane@example.com"
+  },
+  "attachments": [
+    {
+      "name": "consent.pdf",
+      "content": "<base64-encoded file content>"
+    }
+  ]
+}
+```
+
+- `form_data` (object, required) — key-value pairs matching the form's field schema
+- `attachments` (array, optional) — file attachments; each item requires `name` (filename) and `content` (base64-encoded)
+
+**Response:**
+- `201` — submission accepted (no body)
+- `400` — missing required `form_data` field
+- `404` — form not found
+
+**Ruby usage:**
+```ruby
+client = Paubox::FormsClient.new
+
+# Text fields only
+client.submit_form('550e8400-e29b-41d4-a716-446655440000',
+  form_data: { first_name: 'Jane', last_name: 'Smith', email: 'jane@example.com' })
+
+# With file attachments
+client.submit_form('550e8400-e29b-41d4-a716-446655440000',
+  form_data: { first_name: 'Jane', signature: '{signature_field}' },
+  attachments: [
+    { name: 'consent.pdf', content: Base64.strict_encode64(File.binread('consent.pdf')) }
+  ])
+```

--- a/lib/paubox.rb
+++ b/lib/paubox.rb
@@ -8,6 +8,8 @@ require 'paubox/mail_to_message'
 require 'paubox/message'
 require 'paubox/templated_message'
 require 'paubox/email_disposition'
+require 'paubox/form'
+require 'paubox/forms_client'
 require 'mail/paubox'
 
 module Paubox

--- a/lib/paubox/form.rb
+++ b/lib/paubox/form.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Paubox
+  class Form
+    attr_reader :id, :title, :description, :form_html, :form_json, :form_css,
+                :vanity_url, :version, :active, :customer_id, :signable,
+                :signature_confirmation_label, :submission_count, :type,
+                :deleted, :archived, :created_at, :updated_at
+
+    def initialize(args = {})
+      @id                           = args['id']
+      @title                        = args['title']
+      @description                  = args['description']
+      @form_html                    = args['form_html']
+      @form_json                    = args['form_json']
+      @form_css                     = args['form_css']
+      @vanity_url                   = args['vanity_url']
+      @version                      = args['version']
+      @active                       = args['active']
+      @customer_id                  = args['customer_id']
+      @signable                     = args['signable']
+      @signature_confirmation_label = args['signature_confirmation_label']
+      @submission_count             = args['submission_count']
+      @type                         = args['type']
+      @deleted                      = args['deleted']
+      @archived                     = args['archived']
+      @created_at                   = args['created_at']
+      @updated_at                   = args['updated_at']
+    end
+
+    def active?
+      @active
+    end
+
+    def deleted?
+      @deleted
+    end
+
+    def archived?
+      @archived
+    end
+
+    def signable?
+      @signable
+    end
+  end
+end

--- a/lib/paubox/forms_client.rb
+++ b/lib/paubox/forms_client.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Paubox
+  class FormsClient
+    require 'rest-client'
+
+    FORMS_HOST     = 'next.paubox.com'
+    FORMS_PROTOCOL = 'https://'
+
+    def initialize(args = {})
+      @host     = args[:host]     || FORMS_HOST
+      @protocol = args[:protocol] || FORMS_PROTOCOL
+    end
+
+    def get_form(form_id)
+      url      = "#{@protocol}#{@host}/public/form_data/#{form_id}"
+      response = RestClient.get(url, accept: :json)
+      Paubox::Form.new(JSON.parse(response.body))
+    end
+
+    def submit_form(form_id, form_data:, attachments: [])
+      url     = "#{@protocol}#{@host}/api/forms/#{form_id}/submissions"
+      payload = { form_data: form_data }
+      payload[:attachments] = attachments unless attachments.empty?
+      RestClient.post(url, payload.to_json, content_type: :json, accept: :json)
+    end
+  end
+end

--- a/spec/helpers/form_helper.rb
+++ b/spec/helpers/form_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Helpers
+  module FormHelper
+    FORM_ID = '550e8400-e29b-41d4-a716-446655440000'
+
+    def sample_form_response
+      {
+        'id'                           => FORM_ID,
+        'title'                        => 'Patient Intake Form',
+        'description'                  => 'Please complete before your appointment.',
+        'form_json'                    => {},
+        'form_html'                    => '<form>...</form>',
+        'form_css'                     => 'form { font-family: sans-serif; }',
+        'vanity_url'                   => nil,
+        'version'                      => 1,
+        'active'                       => true,
+        'customer_id'                  => 123,
+        'signable'                     => false,
+        'signature_confirmation_label' => nil,
+        'submission_count'             => 42,
+        'type'                         => nil,
+        'deleted'                      => false,
+        'archived'                     => false,
+        'created_at'                   => '2024-01-15T10:30:00Z',
+        'updated_at'                   => '2024-06-01T08:00:00Z'
+      }
+    end
+
+    def sample_form_data
+      { first_name: 'Jane', last_name: 'Smith', email: 'jane@example.com' }
+    end
+
+    def sample_attachments
+      [{ name: 'consent.pdf', content: 'JVBERi0xLjQ...' }]
+    end
+  end
+end

--- a/spec/paubox/form_spec.rb
+++ b/spec/paubox/form_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require './spec/helpers/form_helper'
+
+RSpec.configure do |c|
+  c.include Helpers::FormHelper
+end
+
+RSpec.describe Paubox::Form do
+  subject(:form) { described_class.new(sample_form_response) }
+
+  describe '#initialize' do
+    it 'parses id' do
+      expect(form.id).to eq '550e8400-e29b-41d4-a716-446655440000'
+    end
+
+    it 'parses title' do
+      expect(form.title).to eq 'Patient Intake Form'
+    end
+
+    it 'parses description' do
+      expect(form.description).to eq 'Please complete before your appointment.'
+    end
+
+    it 'parses form_html' do
+      expect(form.form_html).to eq '<form>...</form>'
+    end
+
+    it 'parses form_json' do
+      expect(form.form_json).to eq({})
+    end
+
+    it 'parses form_css' do
+      expect(form.form_css).to eq 'form { font-family: sans-serif; }'
+    end
+
+    it 'parses submission_count' do
+      expect(form.submission_count).to eq 42
+    end
+
+    it 'parses customer_id' do
+      expect(form.customer_id).to eq 123
+    end
+
+    it 'parses created_at' do
+      expect(form.created_at).to eq '2024-01-15T10:30:00Z'
+    end
+
+    it 'parses updated_at' do
+      expect(form.updated_at).to eq '2024-06-01T08:00:00Z'
+    end
+
+    it 'handles nil optional fields' do
+      form = described_class.new({})
+      expect(form.title).to be_nil
+      expect(form.description).to be_nil
+    end
+  end
+
+  describe '#active?' do
+    it 'returns true when active' do
+      expect(form.active?).to be true
+    end
+
+    it 'returns false when inactive' do
+      expect(described_class.new(sample_form_response.merge('active' => false)).active?).to be false
+    end
+  end
+
+  describe '#deleted?' do
+    it 'returns false when not deleted' do
+      expect(form.deleted?).to be false
+    end
+
+    it 'returns true when deleted' do
+      expect(described_class.new(sample_form_response.merge('deleted' => true)).deleted?).to be true
+    end
+  end
+
+  describe '#archived?' do
+    it 'returns false when not archived' do
+      expect(form.archived?).to be false
+    end
+
+    it 'returns true when archived' do
+      expect(described_class.new(sample_form_response.merge('archived' => true)).archived?).to be true
+    end
+  end
+
+  describe '#signable?' do
+    it 'returns false when not signable' do
+      expect(form.signable?).to be false
+    end
+
+    it 'returns true when signable' do
+      expect(described_class.new(sample_form_response.merge('signable' => true)).signable?).to be true
+    end
+  end
+end

--- a/spec/paubox/forms_client_spec.rb
+++ b/spec/paubox/forms_client_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require './spec/helpers/form_helper'
+
+RSpec.configure do |c|
+  c.include Helpers::FormHelper
+end
+
+RSpec.describe Paubox::FormsClient do
+  let(:client)  { described_class.new }
+  let(:form_id) { Helpers::FormHelper::FORM_ID }
+  let(:get_url) { "https://next.paubox.com/public/form_data/#{form_id}" }
+  let(:post_url) { "https://next.paubox.com/api/forms/#{form_id}/submissions" }
+
+  describe '#initialize' do
+    it 'uses default host and protocol' do
+      expect(client.instance_variable_get(:@host)).to eq 'next.paubox.com'
+      expect(client.instance_variable_get(:@protocol)).to eq 'https://'
+    end
+
+    it 'allows host override' do
+      custom = described_class.new(host: 'localhost:3000', protocol: '')
+      expect(custom.instance_variable_get(:@host)).to eq 'localhost:3000'
+      expect(custom.instance_variable_get(:@protocol)).to eq ''
+    end
+  end
+
+  describe '#get_form' do
+    it 'makes GET request to the correct URL' do
+      stub_request(:get, get_url)
+        .to_return(status: 200, body: sample_form_response.to_json,
+                   headers: { 'Content-Type' => 'application/json' })
+
+      client.get_form(form_id)
+
+      expect(a_request(:get, get_url)).to have_been_made.once
+    end
+
+    it 'returns a Paubox::Form' do
+      stub_request(:get, get_url)
+        .to_return(status: 200, body: sample_form_response.to_json,
+                   headers: { 'Content-Type' => 'application/json' })
+
+      form = client.get_form(form_id)
+
+      expect(form).to be_a(Paubox::Form)
+      expect(form.title).to eq 'Patient Intake Form'
+      expect(form.active?).to be true
+    end
+  end
+
+  describe '#submit_form' do
+    it 'makes POST request to the correct URL' do
+      stub_request(:post, post_url).to_return(status: 201)
+
+      client.submit_form(form_id, form_data: sample_form_data)
+
+      expect(a_request(:post, post_url)).to have_been_made.once
+    end
+
+    it 'sends form_data in the request body' do
+      stub_request(:post, post_url).to_return(status: 201)
+
+      client.submit_form(form_id, form_data: sample_form_data)
+
+      expect(a_request(:post, post_url).with(body: { form_data: sample_form_data }.to_json))
+        .to have_been_made.once
+    end
+
+    it 'includes attachments when provided' do
+      stub_request(:post, post_url).to_return(status: 201)
+
+      client.submit_form(form_id, form_data: sample_form_data, attachments: sample_attachments)
+
+      expected_body = { form_data: sample_form_data, attachments: sample_attachments }.to_json
+      expect(a_request(:post, post_url).with(body: expected_body)).to have_been_made.once
+    end
+
+    it 'omits attachments key when empty' do
+      stub_request(:post, post_url).to_return(status: 201)
+
+      client.submit_form(form_id, form_data: sample_form_data)
+
+      expect(a_request(:post, post_url).with { |req| !req.body.include?('attachments') })
+        .to have_been_made.once
+    end
+
+    it 'returns the HTTP response' do
+      stub_request(:post, post_url).to_return(status: 201)
+
+      response = client.submit_form(form_id, form_data: sample_form_data)
+
+      expect(response.code).to eq 201
+    end
+  end
+end


### PR DESCRIPTION
Introduces Paubox::FormsClient (unauthenticated, next.paubox.com) with
get_form and submit_form methods, and Paubox::Form to parse form metadata
responses. Adds full specs, api.md reference, and CLAUDE.md developer
context. Updates README with Forms usage examples.

https://claude.ai/code/session_018EiH4BFCK2SGjskkNPuqTy