### PR TITLE
Add Paubox Forms API support

### DIFF
--- a/api.md
+++ b/api.md
@@ -177,7 +177,7 @@ Returns service health. No authentication required in practice.
 ### Base URL
 
 ```
-https://next.paubox.com
+https://apx.paubox.com/forms
 ```
 
 ---

--- a/lib/paubox/forms_client.rb
+++ b/lib/paubox/forms_client.rb
@@ -4,22 +4,24 @@ module Paubox
   class FormsClient
     require 'rest-client'
 
-    FORMS_HOST     = 'next.paubox.com'
+    FORMS_HOST     = 'apx.paubox.com'
     FORMS_PROTOCOL = 'https://'
+    FORMS_BASE     = '/forms'
 
     def initialize(args = {})
       @host     = args[:host]     || FORMS_HOST
       @protocol = args[:protocol] || FORMS_PROTOCOL
+      @base     = args[:base]     || FORMS_BASE
     end
 
     def get_form(form_id)
-      url      = "#{@protocol}#{@host}/public/form_data/#{form_id}"
+      url      = "#{@protocol}#{@host}#{@base}/public/form_data/#{form_id}"
       response = RestClient.get(url, accept: :json)
       Paubox::Form.new(JSON.parse(response.body))
     end
 
     def submit_form(form_id, form_data:, attachments: [])
-      url     = "#{@protocol}#{@host}/api/forms/#{form_id}/submissions"
+      url     = "#{@protocol}#{@host}#{@base}/api/forms/#{form_id}/submissions"
       payload = { form_data: form_data }
       payload[:attachments] = attachments unless attachments.empty?
       RestClient.post(url, payload.to_json, content_type: :json, accept: :json)

--- a/spec/paubox/forms_client_spec.rb
+++ b/spec/paubox/forms_client_spec.rb
@@ -10,19 +10,21 @@ end
 RSpec.describe Paubox::FormsClient do
   let(:client)  { described_class.new }
   let(:form_id) { Helpers::FormHelper::FORM_ID }
-  let(:get_url) { "https://next.paubox.com/public/form_data/#{form_id}" }
-  let(:post_url) { "https://next.paubox.com/api/forms/#{form_id}/submissions" }
+  let(:get_url)  { "https://apx.paubox.com/forms/public/form_data/#{form_id}" }
+  let(:post_url) { "https://apx.paubox.com/forms/api/forms/#{form_id}/submissions" }
 
   describe '#initialize' do
-    it 'uses default host and protocol' do
-      expect(client.instance_variable_get(:@host)).to eq 'next.paubox.com'
+    it 'uses default host, protocol, and base' do
+      expect(client.instance_variable_get(:@host)).to eq 'apx.paubox.com'
       expect(client.instance_variable_get(:@protocol)).to eq 'https://'
+      expect(client.instance_variable_get(:@base)).to eq '/forms'
     end
 
-    it 'allows host override' do
-      custom = described_class.new(host: 'localhost:3000', protocol: '')
+    it 'allows host, protocol, and base override' do
+      custom = described_class.new(host: 'localhost:3000', protocol: '', base: '')
       expect(custom.instance_variable_get(:@host)).to eq 'localhost:3000'
       expect(custom.instance_variable_get(:@protocol)).to eq ''
+      expect(custom.instance_variable_get(:@base)).to eq ''
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds `Paubox::FormsClient` — unauthenticated HTTP client for the Forms API (`https://apx.paubox.com/forms`) with `get_form` and `submit_form` methods
- Adds `Paubox::Form` — response model for form metadata, with predicate methods (`active?`, `deleted?`, `archived?`, `signable?`)
- Adds `api.md` — full API reference covering both the Email API and Forms API
- Adds `CLAUDE.md` — developer/AI context for the codebase
- Updates `README.md` with a Paubox Forms usage section

## Test plan

- [ ] `bundle exec rspec` — all 68 tests pass (48 existing + 20 new)
- [ ] `get_form` makes a GET to `https://apx.paubox.com/forms/public/form_data/{form_id}` and returns a `Paubox::Form`
- [ ] `submit_form` makes a POST to `https://apx.paubox.com/forms/api/forms/{form_id}/submissions` with `form_data` and optional `attachments`
- [ ] No regressions in existing Email API specs

https://claude.ai/code/session_018EiH4BFCK2SGjskkNPuqTy

---
_Generated by [Claude Code](https://claude.ai/code/session_018EiH4BFCK2SGjskkNPuqTy)_