### PR TITLE
Update contributing link for renamed paubox-ruby repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ client.submit_form('550e8400-e29b-41d4-a716-446655440000',
 <a name="#contributing"></a>
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/paubox/paubox_ruby.
+Bug reports and pull requests are welcome on GitHub at https://github.com/paubox/paubox-ruby.
 
 
 <a name="#license"></a>


### PR DESCRIPTION
This repo is being renamed `paubox_ruby` -> `paubox-ruby` to match the rest of the SDK fleet (`paubox-node`, `paubox-php`, `paubox-java`, `paubox-csharp`, `paubox-go`, `paubox-python3`).

**Merge AFTER the rename lands.** Post-rename the old URL redirects anyway, so there is no breakage window in that order.

## Changed

`README.md:360` -- the contributing link. That is the only repo-name reference in this repo.

## Deliberately NOT changed -- these are gem API, not repo references

Three identifiers are being conflated here, and only the first is changing:

| Identifier | Value | Changing? |
|---|---|---|
| Repo name | `paubox_ruby` -> `paubox-ruby` | yes |
| Gem name (`spec.name`) | `paubox` | no |
| Require path | `paubox_ruby` | **no** |

- `lib/paubox_ruby.rb` -- a published shim that customers can `require 'paubox_ruby'`. Renaming it is a breaking change to the gem's public API.
- `bin/console:5`, `spec/spec_helper.rb:4` -- consume that require path.
- `CLAUDE.md:14` -- accurately documents the shim.
- `Gemfile:5` -- refers to the gemspec **filename** `paubox_ruby.gemspec`, which is unchanged.

Renaming the repo has no effect on RubyGems. The published gem stays `paubox` and nothing customers install or require changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)