### PR TITLE
Remove api_user from auth and move base URLs to api.paubox.com

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@ lib/
   paubox_ruby.rb             # Alias for paubox.rb
   paubox/
     version.rb               # Gem version constant
-    client.rb                # Email API client (authenticated, api.paubox.net)
-    forms_client.rb          # Forms API client (apx.paubox.com; Bearer auth on management endpoints)
+    client.rb                # Email API client (authenticated, api.paubox.com)
+    forms_client.rb          # Forms API client (api.paubox.com/forms; Bearer auth on management endpoints)
     message.rb               # Builds send-message API payload from a hash
     templated_message.rb     # Extends Message for template-based sends
     mail_to_message.rb       # Adapts Ruby Mail::Message to API payload
@@ -38,8 +38,8 @@ spec/
 
 | Class | Responsibility |
 |---|---|
-| `Paubox::Client` | Authenticated HTTP client for the Email API. Token auth via `Authorization: Token token=<key>`. Base URL: `https://api.paubox.net/v1/<api_user>`. |
-| `Paubox::FormsClient` | HTTP client for the Forms API. Base URL: `https://apx.paubox.com/forms`. Public endpoints (`get_form`, `submit_form`) send no auth headers; management endpoints (list/create/find/update/archive/copy forms, stats, submissions, CSV/PDF export) require a "forms"-scoped API key sent as `Authorization: Bearer <api_key>`. |
+| `Paubox::Client` | Authenticated HTTP client for the Email API. Token auth via `Authorization: Token token=<key>`. Base URL: `https://api.paubox.com/v1`. |
+| `Paubox::FormsClient` | HTTP client for the Forms API. Base URL: `https://api.paubox.com/forms`. Public endpoints (`get_form`, `submit_form`) send no auth headers; management endpoints (list/create/find/update/archive/copy forms, stats, submissions, CSV/PDF export) require a "forms"-scoped API key sent as `Authorization: Bearer <api_key>`. |
 | `Paubox::Message` | Builds the JSON payload for `/messages`. Accepts `from`, `to`, `cc`, `bcc`, `subject`, `text_content`, `html_content`, `attachments`. |
 | `Paubox::TemplatedMessage` | Extends `Message`; overrides `send_message_payload` to include `template_name` / `template_values`. |
 | `Paubox::MailToMessage` | Converts a `Mail::Message` object into a Paubox API payload. |
@@ -79,7 +79,7 @@ Fixtures live in `spec/helpers/` as includable modules (e.g. `Helpers::FormHelpe
 
 ## Authentication
 
-- **Email API**: `Authorization: Token token=<api_key>` header on every request. Configured via `Paubox.configure` or `Paubox::Client.new(api_key:, api_user:)`.
+- **Email API**: `Authorization: Token token=<api_key>` header on every request. The API key alone authenticates — no username/user segment is needed. Configured via `Paubox.configure` or `Paubox::Client.new(api_key:)`. `Configuration` keeps a deprecated `api_user` accessor for backward compatibility; it is ignored.
 - **Forms API**: Public endpoints (`get_form`, `submit_form`) need no auth — `Paubox::FormsClient` sends no auth headers for them. Management endpoints require an API key with the "forms" scope (validated server-side, not by the gem), sent as `Authorization: Bearer <api_key>`. This is a separate key from the Email API key: configure it via `Paubox.configure { |c| c.forms_api_key = ... }` or `Paubox::FormsClient.new(api_key:)` — the client never falls back to `Paubox.configuration.api_key`. Calling a management endpoint without a key raises `ArgumentError`. Note: `list_forms` requires `customer_id` (must match the API key's customer, enforced server-side; the gem raises `ArgumentError` if it is missing).
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ Keep your API credentials out of version control. Store these in environment var
 ```ruby
 Paubox.configure do |config|
   config.api_key = ENV['PAUBOX_API_KEY']
-  config.api_user = ENV['PAUBOX_API_USER']
 end
 ```
+
+_Note: earlier versions of this gem also required an `api_user`. It is no longer needed — the API key alone authenticates. The `api_user` configuration option is deprecated and ignored._
 
 If you need to send from multiple domains, you can pass credentials in the options hash when you set Ruby Mail's `Mail#delivery_method`, or when using `Paubox::Message`, when you instantiate `Paubox::Client`.
 
@@ -55,16 +56,14 @@ If you need to send from multiple domains, you can pass credentials in the optio
 ```ruby
 message = Mail.new do
   ...
-  delivery_method(Mail::Paubox, api_key: ENV['PAUBOX_API_KEY'],
-                                api_user: ENV['PAUBOX_API_USER'])
+  delivery_method(Mail::Paubox, api_key: ENV['PAUBOX_API_KEY'])
 end
 ```
 
 **(optional) Setting credentials when using Paubox::Client:**
 
 ```ruby
-client = Paubox::Client.new(api_key: ENV['PAUBOX_API_KEY'],
-                            api_user: ENV['PAUBOX_API_USER'])
+client = Paubox::Client.new(api_key: ENV['PAUBOX_API_KEY'])
 ```
 
 <a name="#usage"></a>

--- a/api.md
+++ b/api.md
@@ -4,20 +4,21 @@
 
 ### Authentication
 
-All Email API requests use token-based authentication. Configure credentials once globally or pass them per client instance.
+All Email API requests use token-based authentication. The API key alone authenticates — no username is required. Configure the key once globally or pass it per client instance.
 
 **Global configuration:**
 ```ruby
 Paubox.configure do |config|
-  config.api_key  = ENV['PAUBOX_API_KEY']
-  config.api_user = ENV['PAUBOX_API_USER']
+  config.api_key = ENV['PAUBOX_API_KEY']
 end
 ```
 
 **Per-instance:**
 ```ruby
-client = Paubox::Client.new(api_key: ENV['PAUBOX_API_KEY'], api_user: ENV['PAUBOX_API_USER'])
+client = Paubox::Client.new(api_key: ENV['PAUBOX_API_KEY'])
 ```
+
+_The `api_user` configuration option is deprecated and ignored._
 
 **Authorization header sent on every request:**
 ```
@@ -27,7 +28,7 @@ Authorization: Token token=<api_key>
 ### Base URL
 
 ```
-https://api.paubox.net/v1/<api_user>
+https://api.paubox.com/v1
 ```
 
 All Email API paths below are relative to this base.
@@ -177,7 +178,7 @@ Returns service health. No authentication required in practice.
 ### Base URL
 
 ```
-https://apx.paubox.com/forms
+https://api.paubox.com/forms
 ```
 
 ---

--- a/lib/paubox.rb
+++ b/lib/paubox.rb
@@ -24,6 +24,10 @@ module Paubox
   end
 
   class Configuration
-    attr_accessor :api_key, :api_user, :forms_api_key
+    attr_accessor :api_key, :forms_api_key
+
+    # Deprecated: api_user is no longer used by the Email API client.
+    # Kept only for backward compatibility; it has no effect on requests.
+    attr_accessor :api_user
   end
 end

--- a/lib/paubox/client.rb
+++ b/lib/paubox/client.rb
@@ -5,12 +5,16 @@ module Paubox
   class Client
     require 'rest-client'
     require 'ostruct'
-    attr_reader :api_key, :api_user, :api_host, :api_protocol, :api_version
+    attr_reader :api_key, :api_host, :api_protocol, :api_version
+
+    # Deprecated: api_user is no longer used for authentication or URLs.
+    # It is kept only for backward compatibility and has no effect on requests.
+    attr_reader :api_user
 
     def initialize(args = {})
       args = defaults.merge(args)
       @api_key = args[:api_key]
-      @api_user = args[:api_user]
+      @api_user = args[:api_user] # deprecated no-op, kept for backward compatibility
       @api_host = args[:api_host]
       @api_protocol = args[:api_protocol]
       @api_version = args[:api_version]
@@ -65,7 +69,7 @@ module Paubox
     end
 
     def api_base_endpoint
-      "#{api_protocol}#{api_host}/#{api_version}/#{api_user}"
+      "#{api_protocol}#{api_host}/#{api_version}"
     end
 
     def request_endpoint(endpoint)
@@ -74,8 +78,8 @@ module Paubox
 
     def defaults
       { api_key: Paubox.configuration.api_key,
-        api_user: Paubox.configuration.api_user,
-        api_host: 'api.paubox.net', 
+        api_user: Paubox.configuration.api_user, # deprecated, unused
+        api_host: 'api.paubox.com',
         api_protocol: 'https://',
         api_version: 'v1',
         test_mode: false }

--- a/lib/paubox/forms_client.rb
+++ b/lib/paubox/forms_client.rb
@@ -5,7 +5,7 @@ require 'rest-client'
 
 module Paubox
   class FormsClient
-    FORMS_HOST     = 'apx.paubox.com'
+    FORMS_HOST     = 'api.paubox.com'
     FORMS_PROTOCOL = 'https://'
     FORMS_BASE     = '/forms'
 

--- a/spec/paubox/client_spec.rb
+++ b/spec/paubox/client_spec.rb
@@ -17,16 +17,22 @@ RSpec.describe Paubox::Client do
     end
 
     it 'can override default parameters' do
-      client = Paubox::Client.new(api_key: 'test_key', api_user: 'paubox_test',
+      client = Paubox::Client.new(api_key: 'test_key',
                                   api_protocol: '', api_host: 'localhost:3000', api_version: 'v2')
-      expect(client.send(:request_endpoint, 'test')).to eq 'localhost:3000/v2/paubox_test/test'
+      expect(client.send(:request_endpoint, 'test')).to eq 'localhost:3000/v2/test'
     end
   end
 
   describe '#api_base_endpoint' do
     it 'returns the correct URI' do
       client = Paubox::Client.new
-      expect(client.send(:api_base_endpoint)).to eq 'https://api.paubox.net/v1/test_user'
+      expect(client.send(:api_base_endpoint)).to eq 'https://api.paubox.com/v1'
+    end
+
+    it 'ignores api_user (deprecated no-op kept for backward compatibility)' do
+      client = Paubox::Client.new(api_key: 'test_key', api_user: 'paubox_test')
+      expect(client.api_user).to eq 'paubox_test'
+      expect(client.send(:api_base_endpoint)).to eq 'https://api.paubox.com/v1'
     end
   end
 

--- a/spec/paubox/forms_client_spec.rb
+++ b/spec/paubox/forms_client_spec.rb
@@ -10,12 +10,12 @@ end
 RSpec.describe Paubox::FormsClient do
   let(:client)  { described_class.new }
   let(:form_id) { Helpers::FormHelper::FORM_ID }
-  let(:get_url)  { "https://apx.paubox.com/forms/public/form_data/#{form_id}" }
-  let(:post_url) { "https://apx.paubox.com/forms/api/forms/#{form_id}/submissions" }
+  let(:get_url)  { "https://api.paubox.com/forms/public/form_data/#{form_id}" }
+  let(:post_url) { "https://api.paubox.com/forms/api/forms/#{form_id}/submissions" }
 
   describe '#initialize' do
     it 'uses default host, protocol, and base' do
-      expect(client.instance_variable_get(:@host)).to eq 'apx.paubox.com'
+      expect(client.instance_variable_get(:@host)).to eq 'api.paubox.com'
       expect(client.instance_variable_get(:@protocol)).to eq 'https://'
       expect(client.instance_variable_get(:@base)).to eq '/forms'
     end

--- a/spec/paubox/forms_client_url_safety_spec.rb
+++ b/spec/paubox/forms_client_url_safety_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Paubox::FormsClient, 'URL path safety' do
         it "rejects form_id=#{bad.inspect} before any HTTP request" do
           expect { call.call(client, bad) }
             .to raise_error(ArgumentError, /form_id must be a UUID string/)
-          expect(WebMock).not_to have_requested(:any, /apx\.paubox\.com/)
+          expect(WebMock).not_to have_requested(:any, /api\.paubox\.com/)
         end
       end
     end
@@ -72,7 +72,7 @@ RSpec.describe Paubox::FormsClient, 'URL path safety' do
       it "rejects submission_id=#{bad.inspect} even when form_id is valid" do
         expect { client.submissions_csv(valid_uuid, submission_id: bad) }
           .to raise_error(ArgumentError, /submission_id must be a UUID string/)
-        expect(WebMock).not_to have_requested(:any, /apx\.paubox\.com/)
+        expect(WebMock).not_to have_requested(:any, /api\.paubox\.com/)
       end
     end
   end
@@ -82,19 +82,19 @@ RSpec.describe Paubox::FormsClient, 'URL path safety' do
       it "rejects form_id=#{bad.inspect} before any HTTP request" do
         expect { client.submission_pdf(bad, another_valid_uuid) }
           .to raise_error(ArgumentError, /form_id must be a UUID string/)
-        expect(WebMock).not_to have_requested(:any, /apx\.paubox\.com/)
+        expect(WebMock).not_to have_requested(:any, /api\.paubox\.com/)
       end
 
       it "rejects submission_id=#{bad.inspect} when form_id is valid" do
         expect { client.submission_pdf(valid_uuid, bad) }
           .to raise_error(ArgumentError, /submission_id must be a UUID string/)
-        expect(WebMock).not_to have_requested(:any, /apx\.paubox\.com/)
+        expect(WebMock).not_to have_requested(:any, /api\.paubox\.com/)
       end
     end
   end
 
   describe 'valid UUIDs are unchanged in the URL' do
-    let(:find_url) { "https://apx.paubox.com/forms/api/forms/#{valid_uuid}" }
+    let(:find_url) { "https://api.paubox.com/forms/api/forms/#{valid_uuid}" }
 
     it 'sends the UUID verbatim (no double-encoding) for valid input' do
       stub_request(:get, find_url)

--- a/spec/paubox/forms_management_spec.rb
+++ b/spec/paubox/forms_management_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Paubox::FormsClient do
   let(:api_key) { 'scoped-forms-api-key' }
   let(:client)  { described_class.new(api_key: api_key) }
   let(:form_id) { Helpers::FormHelper::FORM_ID }
-  let(:base_url) { 'https://apx.paubox.com/forms/api/forms' }
+  let(:base_url) { 'https://api.paubox.com/forms/api/forms' }
   let(:auth_header) { { 'Authorization' => "Bearer #{api_key}" } }
   let(:json_headers) { { 'Content-Type' => 'application/json' } }
 

--- a/spec/paubox/forms_submissions_spec.rb
+++ b/spec/paubox/forms_submissions_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Paubox::FormsClient, 'submissions' do
   let(:client)        { described_class.new(api_key: api_key) }
   let(:form_id)       { Helpers::FormSubmissionHelper::SUBMISSION_FORM_ID }
   let(:submission_id) { Helpers::FormSubmissionHelper::SUBMISSION_ID }
-  let(:base_url)      { "https://apx.paubox.com/forms/api/forms/#{form_id}/submissions" }
+  let(:base_url)      { "https://api.paubox.com/forms/api/forms/#{form_id}/submissions" }
   let(:auth_header)   { { 'Authorization' => "Bearer #{api_key}" } }
 
   before do


### PR DESCRIPTION
The Email API no longer requires a username: the base endpoint is now
https://api.paubox.com/v1 with no api_user path segment, and the API key
alone authenticates. The api_user setting is kept as a deprecated no-op
so existing configurations don't break.

The Forms API host moves from apx.paubox.com to api.paubox.com (the
/forms base path is unchanged). Specs and docs updated to match.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SjHhQ9P5K5yCSM5ZHSnVZJ