### PR TITLE
ci: replace dead Travis config with GitHub Actions (and fix the Ruby 3.4 load error it found)

### DIFF
--- a/.github/scripts/assert_specs_ran.rb
+++ b/.github/scripts/assert_specs_ran.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Fail CI when a green rspec exit code does not mean the suite ran.
+#
+# A passing run is not evidence of coverage: an error outside an example, a
+# stray tag filter, or a spec_helper that stops loading files can leave rspec
+# reporting success having executed almost nothing. The paubox-php suite sat in
+# exactly that state -- 8 tests, 8 errors, 0 assertions -- unnoticed.
+
+require 'json'
+
+# Floor, not a target. Only trips if coverage regresses; adding specs is free.
+MIN_EXAMPLES = 250
+
+summary = JSON.parse(File.read(ARGV.fetch(0))).fetch('summary')
+
+total    = summary.fetch('example_count')
+pending  = summary.fetch('pending_count')
+failures = summary.fetch('failure_count')
+errors   = summary.fetch('errors_outside_of_examples_count')
+executed = total - pending
+
+puts format(
+  'examples=%d executed=%d failures=%d pending=%d errors_outside_examples=%d',
+  total, executed, failures, pending, errors
+)
+
+problems = []
+problems << "#{errors} error(s) outside of examples" if errors.positive?
+if executed < MIN_EXAMPLES
+  problems << "only #{executed} example(s) executed, expected at least #{MIN_EXAMPLES}"
+end
+
+unless problems.empty?
+  warn "FAIL: #{problems.join('; ')}"
+  exit 1
+end
+
+puts "OK: suite executed #{executed} examples"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  spec:
+    name: rspec (ruby ${{ matrix.ruby }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          # Resolves bundler from the gemspec's own '~> 2.0' constraint and
+          # caches the installed gems.
+          bundler-cache: true
+
+      - name: Run specs
+        # Both formatters are explicit: a CLI --format overrides the one in
+        # .rspec, so without this the log would be empty on failure. The JSON
+        # file feeds the gate below.
+        run: >-
+          bundle exec rspec
+          --format documentation
+          --format json --out rspec-results.json
+
+      - name: Assert the suite actually executed
+        run: ruby .github/scripts/assert_specs_ran.rb rspec-results.json

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 # rspec failure tracking
 .rspec_status
 .gem
+
+# rspec JSON output written by CI.
+rspec-results.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.7.8
-before_install: gem install bundler -v 2.3.26

--- a/paubox_ruby.gemspec
+++ b/paubox_ruby.gemspec
@@ -29,6 +29,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'webmock', '~> 2.1'
 
+  # base64 and ostruct left the default gems (base64 in Ruby 3.4, ostruct in
+  # 4.0). lib/ requires both, so they must be declared or the gem fails to load.
+  spec.add_dependency 'base64'
+  spec.add_dependency 'ostruct'
   spec.add_dependency 'mail', '>= 2.5'
   spec.add_dependency 'rest-client', '~> 2.0', '>= 2.0.2'
 end


### PR DESCRIPTION
## What

Replaces the inert `.travis.yml` (pinned to Ruby 2.7.8) with a GitHub Actions rspec matrix over Ruby 3.1–3.4. This repo has **274 examples across 14 spec files and nothing was running them**. The suite is offline — `spec_helper` requires `webmock/rspec`, so no real HTTP.

## The 3.4 failure was a real bug, not a CI problem

Ruby 3.4 failed with `LoadError: base64`. `base64` left the default gems in **3.4**, `lib/paubox/format_helper.rb:6` requires it, and the gemspec never declared it — so **the gem fails to load for anyone on 3.4**, tests or not. `lib/paubox/client.rb:7` requires `ostruct`, same story in Ruby 4.0. Both now declared.

After the fix: `274 examples, 0 failures` on 3.1, 3.2, 3.3 and 3.4.

## Notes

- `.github/scripts/assert_specs_ran.rb` fails on any error outside an example, or an executed count below a floor — pending examples don't count as executed.
- `required_ruby_version` is `>= 2.3` while this matrix starts at 3.1. Raising it is a published-gem contract change, so I left it alone.
