### PR TITLE
chore: reconcile version with RubyGems and add a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+Not yet on RubyGems. The newest published version is still `0.3.2` from October 2022.
+
+### 🚀 New Features
+
+- Add `Paubox::FormsClient` for the Paubox Forms API, with `Paubox::Form` and `Paubox::FormSubmission` models
+  - Public endpoints, no credential attached: `get_form`, `submit_form`
+  - Form management with a scoped API key (`forms` scope, sent as `Authorization: Bearer <key>`): `list_forms`, `find_form`, `create_form`, `update_form`, `archive_form`, `unarchive_form`, `copy_form`, `form_stats`
+  - Submissions: `list_submissions`, `submissions_csv`, `submission_pdf`
+- The Email API no longer requires `api_user` — an API key alone authenticates
+
+### ⚠️ Behavior Changes
+
+- Email API base URLs move to `api.paubox.com`. `api_user` is accepted and ignored, and `Paubox::Client#api_user` is kept as a deprecated reader, so existing configuration keeps working
+- The Forms API host is `api.paubox.com`, moved from the earlier `apx.paubox.com/forms`
+
+### 🔒 Hardening
+
+- Validate and encode caller-supplied values interpolated into Forms request paths. Authenticated endpoints require a UUID; public endpoints encode the segment instead of rejecting it
+- Keep the Bearer token out of exception messages raised from Forms requests
+
+### 🐛 Fixes
+
+- Declare `base64` and `ostruct` as runtime dependencies. Both left the Ruby default gems (`base64` in 3.4, `ostruct` in 4.0) and `lib/` requires them, so the gem failed to load on Ruby 3.4 without them
+
+### 🎉 Enhancements
+
+- Replace the dead Travis config with a GitHub Actions CI workflow running RSpec on Ruby 3.1 through 3.4
+
+## v0.3.2 / 2022-10-06
+
+### 🚀 New Features
+
+- Add support for sending messages using dynamic templates ([#8](https://github.com/Paubox/paubox-ruby/pull/8))
+
+## v0.3.0 / 2019-07-10
+
+### 🎉 Enhancements
+
+- Version bump and dependency maintenance
+
+## v0.2.3 / 2018-10-04
+
+### 🎉 Enhancements
+
+- Relax the `mail` dependency to `>= 2.5`
+- Declare a minimum Ruby version of 2.3
+
+## v0.1.3 / 2018-04-30
+
+### 🎉 Enhancements
+
+- Relax the `mail` dependency to `>= 2.6`
+
+## v0.1.1 / 2018-04-26
+
+### 🐛 Fixes
+
+- Packaging fixes following the initial release
+
+## v0.1.0 / 2018-04-17
+
+### 🚀 Major Release
+
+First release of the Paubox Transactional Email SDK for Ruby.

--- a/lib/paubox/version.rb
+++ b/lib/paubox/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Paubox
-  VERSION = '0.4.0'
+  VERSION = '0.3.2'
 end


### PR DESCRIPTION
Phase 1 of the SDK release automation plan for this repo. No release is cut and no version number is consumed.

## State before

| | |
|---|---|
| RubyGems `paubox` | **0.3.2** (2022-10-06, 175,508 lifetime downloads) |
| `lib/paubox/version.rb` | **0.4.0** |
| Git tags | only `v0.3.0` |
| `CHANGELOG.md` | none |

Three numbers, none of which agreed. `0.4.0` was never built or pushed, and neither was `0.3.1` before it — both are still unused.

## Changes

**`version.rb` reset to `0.3.2`** so the repo, the gem and the tag agree.

**`CHANGELOG.md` added** — the repo never had one. Backfilled from git history, with the unreleased Forms API, auth change, and the `base64`/`ostruct` fix staged under `Unreleased`. Headings are H2: release-please finds its insertion point with `/\n###? v?[0-9[]/`, which an H1 heading does not match.

## Tag created (already applied)

`v0.3.2` at `6e7e8cc` — the commit that set `VERSION = '0.3.2'`, at `2022-10-06T20:53:53Z`. RubyGems recorded the push at `21:03:11Z`, ten minutes later.

Checked before pushing it, per the plan's T6: there is no `.github` directory at all at that commit, and nothing on master triggers on tags, so the tag could not fire a publish.

## What Phase 3 will need

`paubox` is a Part 1 promotion to **1.0.0**, so the release will be pinned with `Release-As`. Worth recording why that is not just a policy choice: seeded at 0.3.2, release-please would propose **0.3.3**. Of the 22 commits since the 0.3.2 commit only 13 parse as conventional, and the substantive ones are not among them — the Forms API, dynamic templates, and the auth change all landed with non-conventional subjects and are dropped from the calculation.

## Cross-package note

`paubox_rails` declares `spec.add_dependency('paubox', '~> 0.3', '>= 0.3.0')`. `~> 0.3` means `>= 0.3, < 1.0`, so **releasing `paubox` 1.0.0 will make it unresolvable for `paubox_rails`** until that constraint is widened. The two gems have to be released in order — `paubox` first, then a `paubox_rails` release that widens to `~> 1.0`. Tracked on the rails side; nothing to do here.

## Test plan

- [ ] CI green on Ruby 3.1 through 3.4
- [ ] `git ls-remote --tags origin` shows `v0.3.0` and `v0.3.2`
- [ ] RubyGems still shows 0.3.2 as latest, unchanged