### PR TITLE
fix: target the documented /v1/email and /v1/forms base URLs

### DIFF
--- a/.github/scripts/route-check.sh
+++ b/.github/scripts/route-check.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Probes each base URL with a junk token: api.paubox.com answers unrouted paths
+# with its own HTML 404 page, so a wrong base fails here without credentials.
+#
+# Usage: route-check.sh <url> [url ...]
+#        <command printing one URL per line> | route-check.sh
+set -eu
+
+MARKER='The resource could not be found'
+TOKEN='route-check-not-a-real-key'
+
+urls=$(mktemp)
+fails=$(mktemp)
+trap 'rm -f "$urls" "$fails"' EXIT
+
+if [ "$#" -gt 0 ]; then
+  for u in "$@"; do echo "$u"; done > "$urls"
+else
+  cat > "$urls"
+fi
+
+sed 's#/*$##' "$urls" | grep '^https://' | sort -u > "$urls.clean" || true
+mv "$urls.clean" "$urls"
+
+if [ ! -s "$urls" ]; then
+  echo "route-check: no URLs given" >&2
+  exit 1
+fi
+
+while IFS= read -r url; do
+  if curl -sS -m 20 -H "Authorization: Token token=$TOKEN" "$url" \
+       | grep -qF "$MARKER"; then
+    echo "FAIL $url  <- not routed"
+    echo "$url" >> "$fails"
+  else
+    echo "ok   $url"
+  fi
+done < "$urls"
+
+if [ -s "$fails" ]; then
+  echo "See https://docs.paubox.com for the documented base URLs." >&2
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,24 @@ jobs:
 
       - name: Assert the suite actually executed
         run: ruby .github/scripts/assert_specs_ran.rb rspec-results.json
+
+  route-check:
+    name: Base URLs are routed
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      # Ask the client, so a base URL change cannot pass unprobed.
+      - name: Probe the base URLs the clients build
+        run: |
+          bundle exec ruby -Ilib -rjson -rpaubox -e '
+            Paubox.configure { |c| c.api_key = "route-check" }
+            puts Paubox::Client.new.send(:api_base_endpoint)
+            f = Paubox::FormsClient
+            puts "#{f::FORMS_PROTOCOL}#{f::FORMS_HOST}#{f::FORMS_BASE}"
+          ' | .github/scripts/route-check.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ lib/
   paubox/
     version.rb               # Gem version constant
     client.rb                # Email API client (authenticated, api.paubox.com)
-    forms_client.rb          # Forms API client (api.paubox.com/forms; Bearer auth on management endpoints)
+    forms_client.rb          # Forms API client (api.paubox.com/v1/forms; Bearer auth on management endpoints)
     message.rb               # Builds send-message API payload from a hash
     templated_message.rb     # Extends Message for template-based sends
     mail_to_message.rb       # Adapts Ruby Mail::Message to API payload
@@ -38,8 +38,8 @@ spec/
 
 | Class | Responsibility |
 |---|---|
-| `Paubox::Client` | Authenticated HTTP client for the Email API. Token auth via `Authorization: Token token=<key>`. Base URL: `https://api.paubox.com/v1`. |
-| `Paubox::FormsClient` | HTTP client for the Forms API. Base URL: `https://api.paubox.com/forms`. Public endpoints (`get_form`, `submit_form`) send no auth headers; management endpoints (list/create/find/update/archive/copy forms, stats, submissions, CSV/PDF export) require a "forms"-scoped API key sent as `Authorization: Bearer <api_key>`. |
+| `Paubox::Client` | Authenticated HTTP client for the Email API. Token auth via `Authorization: Token token=<key>`. Base URL: `https://api.paubox.com/v1/email`. |
+| `Paubox::FormsClient` | HTTP client for the Forms API. Base URL: `https://api.paubox.com/v1/forms`. Public endpoints (`get_form`, `submit_form`) send no auth headers; management endpoints (list/create/find/update/archive/copy forms, stats, submissions, CSV/PDF export) require a "forms"-scoped API key sent as `Authorization: Bearer <api_key>`. |
 | `Paubox::Message` | Builds the JSON payload for `/messages`. Accepts `from`, `to`, `cc`, `bcc`, `subject`, `text_content`, `html_content`, `attachments`. |
 | `Paubox::TemplatedMessage` | Extends `Message`; overrides `send_message_payload` to include `template_name` / `template_values`. |
 | `Paubox::MailToMessage` | Converts a `Mail::Message` object into a Paubox API payload. |

--- a/api.md
+++ b/api.md
@@ -28,7 +28,7 @@ Authorization: Token token=<api_key>
 ### Base URL
 
 ```
-https://api.paubox.com/v1
+https://api.paubox.com/v1/email
 ```
 
 All Email API paths below are relative to this base.
@@ -178,7 +178,7 @@ Returns service health. No authentication required in practice.
 ### Base URL
 
 ```
-https://api.paubox.com/forms
+https://api.paubox.com/v1/forms
 ```
 
 ---

--- a/lib/paubox/client.rb
+++ b/lib/paubox/client.rb
@@ -69,7 +69,7 @@ module Paubox
     end
 
     def api_base_endpoint
-      "#{api_protocol}#{api_host}/#{api_version}"
+      "#{api_protocol}#{api_host}/#{api_version}/email"
     end
 
     def request_endpoint(endpoint)

--- a/lib/paubox/forms_client.rb
+++ b/lib/paubox/forms_client.rb
@@ -7,7 +7,7 @@ module Paubox
   class FormsClient
     FORMS_HOST     = 'api.paubox.com'
     FORMS_PROTOCOL = 'https://'
-    FORMS_BASE     = '/forms'
+    FORMS_BASE     = '/v1/forms'
 
     TIMEOUT_SECONDS = 30
 

--- a/spec/paubox/client_spec.rb
+++ b/spec/paubox/client_spec.rb
@@ -19,20 +19,20 @@ RSpec.describe Paubox::Client do
     it 'can override default parameters' do
       client = Paubox::Client.new(api_key: 'test_key',
                                   api_protocol: '', api_host: 'localhost:3000', api_version: 'v2')
-      expect(client.send(:request_endpoint, 'test')).to eq 'localhost:3000/v2/test'
+      expect(client.send(:request_endpoint, 'test')).to eq 'localhost:3000/v2/email/test'
     end
   end
 
   describe '#api_base_endpoint' do
     it 'returns the correct URI' do
       client = Paubox::Client.new
-      expect(client.send(:api_base_endpoint)).to eq 'https://api.paubox.com/v1'
+      expect(client.send(:api_base_endpoint)).to eq 'https://api.paubox.com/v1/email'
     end
 
     it 'ignores api_user (deprecated no-op kept for backward compatibility)' do
       client = Paubox::Client.new(api_key: 'test_key', api_user: 'paubox_test')
       expect(client.api_user).to eq 'paubox_test'
-      expect(client.send(:api_base_endpoint)).to eq 'https://api.paubox.com/v1'
+      expect(client.send(:api_base_endpoint)).to eq 'https://api.paubox.com/v1/email'
     end
   end
 

--- a/spec/paubox/forms_client_spec.rb
+++ b/spec/paubox/forms_client_spec.rb
@@ -10,14 +10,14 @@ end
 RSpec.describe Paubox::FormsClient do
   let(:client)  { described_class.new }
   let(:form_id) { Helpers::FormHelper::FORM_ID }
-  let(:get_url)  { "https://api.paubox.com/forms/public/form_data/#{form_id}" }
-  let(:post_url) { "https://api.paubox.com/forms/api/forms/#{form_id}/submissions" }
+  let(:get_url)  { "https://api.paubox.com/v1/forms/public/form_data/#{form_id}" }
+  let(:post_url) { "https://api.paubox.com/v1/forms/api/forms/#{form_id}/submissions" }
 
   describe '#initialize' do
     it 'uses default host, protocol, and base' do
       expect(client.instance_variable_get(:@host)).to eq 'api.paubox.com'
       expect(client.instance_variable_get(:@protocol)).to eq 'https://'
-      expect(client.instance_variable_get(:@base)).to eq '/forms'
+      expect(client.instance_variable_get(:@base)).to eq '/v1/forms'
     end
 
     it 'allows host, protocol, and base override' do

--- a/spec/paubox/forms_client_url_safety_spec.rb
+++ b/spec/paubox/forms_client_url_safety_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Paubox::FormsClient, 'URL path safety' do
   end
 
   describe 'valid UUIDs are unchanged in the URL' do
-    let(:find_url) { "https://api.paubox.com/forms/api/forms/#{valid_uuid}" }
+    let(:find_url) { "https://api.paubox.com/v1/forms/api/forms/#{valid_uuid}" }
 
     it 'sends the UUID verbatim (no double-encoding) for valid input' do
       stub_request(:get, find_url)

--- a/spec/paubox/forms_management_spec.rb
+++ b/spec/paubox/forms_management_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Paubox::FormsClient do
   let(:api_key) { 'scoped-forms-api-key' }
   let(:client)  { described_class.new(api_key: api_key) }
   let(:form_id) { Helpers::FormHelper::FORM_ID }
-  let(:base_url) { 'https://api.paubox.com/forms/api/forms' }
+  let(:base_url) { 'https://api.paubox.com/v1/forms/api/forms' }
   let(:auth_header) { { 'Authorization' => "Bearer #{api_key}" } }
   let(:json_headers) { { 'Content-Type' => 'application/json' } }
 

--- a/spec/paubox/forms_submissions_spec.rb
+++ b/spec/paubox/forms_submissions_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Paubox::FormsClient, 'submissions' do
   let(:client)        { described_class.new(api_key: api_key) }
   let(:form_id)       { Helpers::FormSubmissionHelper::SUBMISSION_FORM_ID }
   let(:submission_id) { Helpers::FormSubmissionHelper::SUBMISSION_ID }
-  let(:base_url)      { "https://api.paubox.com/forms/api/forms/#{form_id}/submissions" }
+  let(:base_url)      { "https://api.paubox.com/v1/forms/api/forms/#{form_id}/submissions" }
   let(:auth_header)   { { 'Authorization' => "Bearer #{api_key}" } }
 
   before do


### PR DESCRIPTION
`api.paubox.com` routes `/v1/email` and `/v1/forms`. It answers with its own HTML 404
page for `/v1` and `/forms`, so every request this SDK built failed before reaching the
API.

The test suites asserted the unrouted URLs against a mocked transport, so they stayed
green while nothing could succeed. They now assert the documented bases.

Verified against the live API from this branch: a send returns 200 and delivers, and a
receipt lookup authenticates.

## route-check CI job

Also adds a `route-check` job. It asks the client for the base URLs it actually builds,
then probes each one with a junk token: a routed path answers from the API, an unrouted
one answers with the gateway page. No credentials required, so it runs on every PR.
Confirmed it fails on the previous bases and passes on these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
