### PR TITLE
feat: add scheduled send support

### DIFF
--- a/lib/paubox/client.rb
+++ b/lib/paubox/client.rb
@@ -54,6 +54,43 @@ module Paubox
     end
     alias message_receipt email_disposition
 
+    def schedule_mail(mail, scheduled_at)
+      case mail
+      when Mail::Message
+        allow_non_tls = mail.allow_non_tls.nil? ? false : mail.allow_non_tls
+        msg_payload = MailToMessage.new(mail, allow_non_tls: allow_non_tls).send_message_payload
+        msg_data = JSON.parse(msg_payload)['data']['message']
+      when Hash
+        msg_data = Message.new(mail).send_message_payload
+        msg_data = JSON.parse(msg_data)['data']['message']
+      when Paubox::Message
+        msg_data = JSON.parse(mail.send_message_payload)['data']['message']
+      end
+      payload = { data: { message: msg_data, scheduled_at: scheduled_at } }.to_json
+      url = request_endpoint('schedule')
+      response = RestClient.post(url, payload, auth_header)
+      JSON.parse(response.body)
+    end
+
+    def get_scheduled(source_tracking_id)
+      url = request_endpoint("schedule/#{source_tracking_id}")
+      response = RestClient.get(url, auth_header)
+      JSON.parse(response.body)
+    end
+
+    def reschedule(source_tracking_id, scheduled_at)
+      url = request_endpoint("schedule/#{source_tracking_id}")
+      payload = { scheduled_at: scheduled_at }.to_json
+      response = RestClient.patch(url, payload, auth_header)
+      JSON.parse(response.body)
+    end
+
+    def cancel_scheduled(source_tracking_id)
+      url = request_endpoint("schedule/#{source_tracking_id}/cancel")
+      response = RestClient.post(url, nil, auth_header)
+      JSON.parse(response.body)
+    end
+
     def send_request(method: :get, payload: {}, path: '')
       url = request_endpoint(path)
 

--- a/spec/paubox/client_spec.rb
+++ b/spec/paubox/client_spec.rb
@@ -52,5 +52,46 @@ RSpec.describe Paubox::Client do
       response = client.send_request(method: :post, payload: {}, path: 'dynamic_templates')
       expect(response.code).to eq 200
     end
-  end 
+  end
+
+  describe '#schedule_mail' do
+    it 'posts to the schedule endpoint' do
+      client = Paubox::Client.new(api_key: 'test_key')
+      stub_request(:post, client.send(:request_endpoint, 'schedule'))
+        .to_return(status: 200, body: '{"sourceTrackingId":"tid","scheduledAt":"2025-12-25T15:00:00Z","state":"pending","data":"Service OK"}')
+      mail = { from: 'sender@example.com', to: ['recipient@example.com'], subject: 'Test', text_content: 'Hello' }
+      response = client.schedule_mail(mail, '2025-12-25T15:00:00Z')
+      expect(response['state']).to eq 'pending'
+    end
+  end
+
+  describe '#get_scheduled' do
+    it 'gets scheduled message status' do
+      client = Paubox::Client.new(api_key: 'test_key')
+      stub_request(:get, client.send(:request_endpoint, 'schedule/tid-123'))
+        .to_return(status: 200, body: '{"sourceTrackingId":"tid-123","state":"pending"}')
+      response = client.get_scheduled('tid-123')
+      expect(response['state']).to eq 'pending'
+    end
+  end
+
+  describe '#reschedule' do
+    it 'patches the scheduled message' do
+      client = Paubox::Client.new(api_key: 'test_key')
+      stub_request(:patch, client.send(:request_endpoint, 'schedule/tid-123'))
+        .to_return(status: 200, body: '{"sourceTrackingId":"tid-123","scheduledAt":"2025-12-26T10:00:00Z","data":"Rescheduled"}')
+      response = client.reschedule('tid-123', '2025-12-26T10:00:00Z')
+      expect(response['data']).to eq 'Rescheduled'
+    end
+  end
+
+  describe '#cancel_scheduled' do
+    it 'cancels a scheduled message' do
+      client = Paubox::Client.new(api_key: 'test_key')
+      stub_request(:post, client.send(:request_endpoint, 'schedule/tid-123/cancel'))
+        .to_return(status: 200, body: '{"sourceTrackingId":"tid-123","state":"cancelled","data":"Cancelled"}')
+      response = client.cancel_scheduled('tid-123')
+      expect(response['state']).to eq 'cancelled'
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add `schedule_mail`, `get_scheduled`, `reschedule`, and `cancel_scheduled` methods to `Paubox::Client`
- Targets the 4 `/schedule` endpoints: POST, GET, PATCH, POST cancel
- WebMock-stubbed specs for all 4 methods

## Test plan
- [x] Tests pass (`bundle exec rspec` — 9 examples)
- [ ] Integration test against staging with valid API key